### PR TITLE
Removed variable shadowing of Adapter in glee.js

### DIFF
--- a/src/lib/glee.js
+++ b/src/lib/glee.js
@@ -30,7 +30,7 @@ class Glee extends EventEmitter {
    * @param {AsyncAPIServer} server AsyncAPI Server to use with the adapter.
    * @param {AsyncAPIDocument} parsedAsyncAPI The AsyncAPI document.
    */
-  addAdapter (Adapter, { serverName, server, parsedAsyncAPI }) {
+  addAdapter ({serverName, server, parsedAsyncAPI }) {
     this.adapters.push({Adapter, serverName, server, parsedAsyncAPI})
   }
 


### PR DESCRIPTION
Issue#115

**Description**
Removed Adapter from formal parameter of addAdapter() (line 33) so that there is no variable shadowing in the code.
