### PR TITLE
Removing variable shadowing

### DIFF
--- a/src/lib/adapter.js
+++ b/src/lib/adapter.js
@@ -24,7 +24,8 @@ class GleeAdapter extends EventEmitter {
 
     const uriTemplateValues = {}
     process.env.GLEE_SERVER_VARIABLES?.split(',').forEach(t => {
-      const [server, variable, value] = t.split(':')
+      copyserv = server
+      const [copyserv, variable, value] = t.split(':')
       if (server === this.serverName) uriTemplateValues[variable] = value
     })
     this.serverUrlExpanded  = uriTemplates(this.AsyncAPIServer.url()).fill(uriTemplateValues)

--- a/src/lib/glee.js
+++ b/src/lib/glee.js
@@ -30,7 +30,7 @@ class Glee extends EventEmitter {
    * @param {AsyncAPIServer} server AsyncAPI Server to use with the adapter.
    * @param {AsyncAPIDocument} parsedAsyncAPI The AsyncAPI document.
    */
-  addAdapter (Adapter, { serverName, server, parsedAsyncAPI }) {
+  addAdapter ({serverName, server, parsedAsyncAPI }) {
     this.adapters.push({Adapter, serverName, server, parsedAsyncAPI})
   }
 


### PR DESCRIPTION
Resolves issue#114

Since server had already been declared in the upper scope I declared a new variable copyserv and assigned it with the value of server so that variable shadowing is eliminated.

Snippet from src/lib/adapter.js (check line 27 and line 28)

```
copyserv = server
      const [copyserv, variable, value] = t.split(':')
```