### PR TITLE
refactor: rename adapter to gleeadapter to remove variable shadowing

### DIFF
--- a/src/lib/glee.js
+++ b/src/lib/glee.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'events'
 import async from 'async'
 import Debug from 'debug'
-import Adapter from './adapter.js'
+import GleeAdapter from './adapter.js'
 import Router from './router.js'
 import GleeMessage from './message.js'
 import { matchChannel, duplicateMessage, getParams } from './util.js'
@@ -205,7 +205,7 @@ class Glee extends EventEmitter {
 }
 
 Glee.Message = GleeMessage
-Glee.Adapter = Adapter
+Glee.Adapter = GleeAdapter
 Glee.Router = Router
 
 export default Glee


### PR DESCRIPTION
**Description**
- Renaming Adapter to GleeAdapter (which is concise as this is also the name of the class where it is implemented)

**Related issue(s)**
Fixes #115
Replaces inactive PRs #119 #120 #126