### PR TITLE
fix: npm run dev not reloading when file changes

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -16,6 +16,7 @@ if (command === 'dev') {
     ext: '*',
     watch: [
       '.env',
+      '*',
     ],
     env: {
       NODE_ENV: 'development',


### PR DESCRIPTION
**Description**
The `npm run dev` command was failing to reload the development server when a file changes.