### PR TITLE
feat: read channel.servers before falling back to x-servers

### DIFF
--- a/src/lib/adapter.js
+++ b/src/lib/adapter.js
@@ -114,7 +114,7 @@ class GleeAdapter extends EventEmitter {
         const channel = this.parsedAsyncAPI.channel(channelName)
         if (!channel.hasPublish()) return false
         
-        const channelServers = channel.publish().ext('x-servers') || this.parsedAsyncAPI.serverNames()
+        const channelServers = channel.hasServers() ? channel.servers() : channel.ext('x-servers') || this.parsedAsyncAPI.serverNames()
         return channelServers.includes(this.serverName)
       })
   }


### PR DESCRIPTION
**Description**
So far, Glee has been relying on the `x-servers` extension to link channels with servers. I'm now defaulting to the 2.2.0 channel servers feature instead of the `x-servers` extension.