### PR TITLE
fix: glee.config.js is not being loaded into config object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,19 +15,20 @@ import logger from './middlewares/logger.js'
 import errorLogger from './middlewares/errorLogger.js'
 import validateConnection from './middlewares/validateConnection.js'
 import { startRuntimeServers, triggerFunction } from './lib/runtimes/index.js'
-import { setConfigs } from './lib/configs.js'
+import { initializeConfigs } from './lib/configs.js'
 import { getParsedAsyncAPI } from './lib/asyncapiFile.js'
 import { getSelectedServerNames } from './lib/servers.js'
 
 dotenvExpand(dotenv.config())
 
-export default async function GleeAppInitializer (config = {}) {
+export default async function GleeAppInitializer () {
+  const config = await initializeConfigs()
   const {
     GLEE_DIR,
     GLEE_LIFECYCLE_DIR,
     GLEE_FUNCTIONS_DIR,
     ASYNCAPI_FILE_PATH
-  } = await setConfigs(config)
+  } = config
 
   logWelcome({
     dev: process.env.NODE_ENV === 'development',

--- a/src/lib/configs.js
+++ b/src/lib/configs.js
@@ -7,15 +7,18 @@ let GLEE_FUNCTIONS_DIR
 let GLEE_CONFIG_FILE_PATH
 let ASYNCAPI_FILE_PATH
 
-export async function setConfigs(config) {
+export async function initializeConfigs(config = {}) {
   GLEE_DIR = config.dir || process.cwd()
   GLEE_LIFECYCLE_DIR = path.resolve(GLEE_DIR, config.functionsDir || 'lifecycle')
   GLEE_FUNCTIONS_DIR = path.resolve(GLEE_DIR, config.functionsDir || 'functions')
   GLEE_CONFIG_FILE_PATH = path.resolve(GLEE_DIR, 'glee.config.js')
   ASYNCAPI_FILE_PATH = path.resolve(GLEE_DIR, 'asyncapi.yaml')
-  await loadConfigsFromFile()
+  const configsFromFile = await loadConfigsFromFile()
   
-  return getConfigs()
+  return {
+    ...configsFromFile,
+    ...getConfigs()
+  }
 }
 
 /**
@@ -32,6 +35,7 @@ async function loadConfigsFromFile() {
     GLEE_LIFECYCLE_DIR = projectConfigs.GLEE_LIFECYCLE_DIR ? path.resolve(GLEE_DIR, projectConfigs.GLEE_LIFECYCLE_DIR) : GLEE_LIFECYCLE_DIR 
     GLEE_FUNCTIONS_DIR = projectConfigs.GLEE_FUNCTIONS_DIR ? path.resolve(GLEE_DIR, projectConfigs.GLEE_FUNCTIONS_DIR) : GLEE_FUNCTIONS_DIR 
     ASYNCAPI_FILE_PATH = projectConfigs.ASYNCAPI_FILE_PATH ? path.resolve(GLEE_DIR, projectConfigs.ASYNCAPI_FILE_PATH) : ASYNCAPI_FILE_PATH
+    return projectConfigs
   } catch (e) {
     if (e.code !== 'ERR_MODULE_NOT_FOUND') {
       return console.error(e)


### PR DESCRIPTION
**Description**

I was trying to run the `dummy` example uncommenting the lines here: https://github.com/asyncapi/glee/blob/master/examples/dummy/glee.config.js and found it's not loading the configuration.

This PR is fixing the configuration loader.