### PR TITLE
feat: made message sending api dry

### DIFF
--- a/examples/dummy/functions/onUserSignedUp.ts
+++ b/examples/dummy/functions/onUserSignedUp.ts
@@ -2,7 +2,7 @@ export default async function (event) {
   const user: any = event.payload
   console.log(`${user.displayName} has recently signed up. Sending an email to ${user.email}.`)
   return {
-    broadcast: [{
+    send: [{
       server: 'websockets',
       payload: event.payload,
     }]

--- a/src/lib/functions.ts
+++ b/src/lib/functions.ts
@@ -60,6 +60,7 @@ export async function trigger({
           headers: msg.headers,
           channel: msg.channel || message.channel,
           serverName: msg.server,
+          broadcast: true,
         }))
       })
     }
@@ -71,18 +72,6 @@ export async function trigger({
           headers: msg.headers,
           channel: msg.channel,
         })
-      })
-    }
-
-    if (res?.broadcast) {
-      res.broadcast.forEach((msg) => {
-        app.send(new GleeMessage({
-          payload: msg.payload,
-          headers: msg.headers,
-          channel: msg.channel || message.channel,
-          serverName: msg.server,
-          broadcast: true,
-        }))
       })
     }
   } catch (err) {


### PR DESCRIPTION
**Description**

- Removed broadcast option while sending messages. Only send and reply are available, as mentioned [here](https://github.com/asyncapi/glee/issues/192#issuecomment-978165400).

**Related issue(s)**
Resolves #192 