### PR TITLE
chore: removed broadcast section from functions.md

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -37,7 +37,7 @@ export default async function (event) {
 |---|---|---|
 |send|array&lt;[OutboundMessage](#anatomy-of-an-outbound-message)&gt;|A list of outbound messages to send when the processing of the inbound event has finished. All clients subscribed to the given channel/topic will receive the message.
 |reply|array&lt;[OutboundMessage](#anatomy-of-an-outbound-message)&gt;|A list of outbound messages to send as a reply when the processing of the inbound event has finished. This is useful when the target of your message is the sender of the inbound event. Note, however, that this only works when you're running Glee as a server. For example, using `reply` when receiving a WebSocket message is fine and the reply will exclusively go to the client that sent the message. However, if you're receiving a message from an MQTT broker, `reply` will work exactly the same way as `send` above, and will send the message to all the clients subscribed to the given channel/topic.
-|broadcast|array&lt;[OutboundMessage](#anatomy-of-an-outbound-message)&gt;|A list of outbound messages to send to all the clients. This is only useful when you're running Glee as a server. For example, using `broadcast` when receiving a WebSocket message is fine and the outbound message will go to all the clients that have an open connection with the server. However, if you're receiving a message from an MQTT broker, `broadcast` will work exactly the same way as `send` above, and will send the message to all the clients subscribed to the given channel/topic.
+
 
 ##### Anatomy of an outbound message
 


### PR DESCRIPTION
**Description**

- Functions documentation shows that we can use the broadcast key in the returned object but that's not the case anymore.
- Removed the broadcast key from functions.md file


**Related issue(s)**
Fixes #271 