### PR TITLE
docs: fix links in Markdown files

### DIFF
--- a/examples/social-network/notifications-service/README.md
+++ b/examples/social-network/notifications-service/README.md
@@ -12,6 +12,6 @@ You can start editing the API by modifying `functions/onHello.js` and `asyncapi.
 
 ## Learn More
 
-To learn more about Glee features and API, take a look at the [documentation](https://asyncapi.org/glee/docs).
+To learn more about Glee features and API, take a look at the [documentation](https://github.com/asyncapi/glee/).
 
 You can check out [the Glee Github repository](https://github.com/asyncapi/glee/) - your feedback and contributions are welcome!

--- a/examples/social-network/websocket-server/README.md
+++ b/examples/social-network/websocket-server/README.md
@@ -12,6 +12,6 @@ You can start editing the API by modifying `functions/onHello.js` and `asyncapi.
 
 ## Learn More
 
-To learn more about Glee features and API, take a look at the [documentation](https://asyncapi.org/glee/docs).
+To learn more about Glee features and API, take a look at the [documentation](https://github.com/asyncapi/glee/).
 
 You can check out [the Glee Github repository](https://github.com/asyncapi/glee/) - your feedback and contributions are welcome!

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://github.com/asyncapi/glee/blob/086c449/src"
+    }
+  ]
+}

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -2,6 +2,9 @@
   "ignorePatterns": [
     {
       "pattern": "^https://github.com/asyncapi/glee/blob/086c449/src"
+    },
+    {
+      "pattern": "^https://asyncapi.org/glee/docs"
     }
   ]
 }

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -4,7 +4,7 @@
       "pattern": "^https://github.com/asyncapi/glee/blob/086c449/src"
     },
     {
-      "pattern": "^https://asyncapi.org/glee/docs"
+      "pattern": "^https://www.github.com/asyncapi/glee"
     }
   ]
 }

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -2,9 +2,6 @@
   "ignorePatterns": [
     {
       "pattern": "^https://github.com/asyncapi/glee/blob/086c449/src"
-    },
-    {
-      "pattern": "^https://www.github.com/asyncapi/glee"
     }
   ]
 }


### PR DESCRIPTION
#### Description
this PR is supposed to fix all the [broken links](https://github.com/asyncapi/go-watermill-template/runs/6143307572?check_suite_focus=true) in markdown files across the repo.

- ignoring https://github.com/asyncapi/glee/blob/086c449/src since there are lots of links to this location and checking these links causes GitHub to give 429 (Too many requests) error.
- ignoring https://asyncapi.org/glee/docs for now. I guess we are going to have the docs on the website in the future?