### PR TITLE
fix: ensure backward compatibilty while processing errors

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,6 @@ export default {
   testEnvironment: 'node',
   setupFilesAfterEnv: ['./jest.setup.ts'],
   collectCoverage: true,
-  setupFiles: ['core-js'],
   silent: false,
   testPathIgnorePatterns: ['functions.test.ts'],
   globals: {

--- a/src/lib/glee.ts
+++ b/src/lib/glee.ts
@@ -259,7 +259,7 @@ export default class Glee extends EventEmitter {
   }
 
   private _execErrorMiddleware (emws: ChannelErrorMiddlewareTuple[], index: number, error: Error, message: GleeMessage) {
-    emws.at(index).fn(error, message, (err: Error) => {
+    emws[index].fn(error, message, (err: Error) => {
       if (!emws[index+1]) return
       this._execErrorMiddleware.call(null, emws, index+1, err, message)
     })


### PR DESCRIPTION
**Description**

- replaced `Array.at` function usage with `[]` operator 
- configured Jest to disable polyfilling in test environment

**Related issue(s)**
Fixes #268 