### PR TITLE
fix: typescript error in MQTT adapter

### DIFF
--- a/src/adapters/mqtt/index.ts
+++ b/src/adapters/mqtt/index.ts
@@ -58,7 +58,7 @@ class MqttAdapter extends Adapter {
         username: userAndPasswordSecurityReq ? process.env.GLEE_USERNAME : undefined,
         password: userAndPasswordSecurityReq ? process.env.GLEE_PASSWORD : undefined,
         ca: X509SecurityReq ? certs : undefined,
-      })
+      } as any)
 
       this.client.on('connect', () => {
         if (!this.firstConnect) {


### PR DESCRIPTION
TypeScript compilation is failing. I'm casting this object as any for the lack of a better alternative right now.