### PR TITLE
Generate types for message payloads using Modelina

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@asyncapi/generator": "^1.9.14",
     "@asyncapi/html-template": "^0.24.10",
     "@asyncapi/markdown-template": "^1.1.1",
+    "@asyncapi/modelina": "^1.2.1",
     "@asyncapi/parser": "^1.13.1",
     "@types/jest": "^27.4.0",
     "@types/qs": "^6.9.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import existsInAsyncAPI from './middlewares/existsInAsyncAPI.js'
 import logger from './middlewares/logger.js'
 import generateDocs from './lib/docs.js'
 import errorLogger from './middlewares/errorLogger.js'
+import generateTypes from './lib/types.js'
 import validateConnection from './middlewares/validateConnection.js'
 import { initializeConfigs } from './lib/configs.js'
 import { getParsedAsyncAPI } from './lib/asyncapiFile.js'
@@ -50,7 +51,6 @@ export default async function GleeAppInitializer () {
   const channelNames = parsedAsyncAPI.channelNames()
 
   const app = new Glee(config)
-
   await registerAdapters(app, parsedAsyncAPI, config)
 
   app.use(existsInAsyncAPI(parsedAsyncAPI))
@@ -63,6 +63,7 @@ export default async function GleeAppInitializer () {
   app.use(errorLogger)
   app.useOutbound(errorLogger)
   generateDocs(parsedAsyncAPI, config, null)
+  generateTypes(parsedAsyncAPI, config, null)
 
   channelNames.forEach((channelName) => {
     const channel = parsedAsyncAPI.channel(channelName)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,63 @@
+import { TypeScriptGenerator } from '@asyncapi/modelina';
+import fs from 'fs'
+import path from 'path'
+import { logInfoMessage, logError } from './logger.js'
+
+export default async (spec, config, resDir) => {
+    logInfoMessage(`Generating types for your parsed specification...`)
+    // Create directory to store types based on the idea - /types/`operationId`.d.t.s
+    mkDirByPathSync('operations/types')
+    
+    const channelNames = spec.channelNames()
+    channelNames.forEach((channelName) => {
+        const channel = spec.channel(channelName)
+        if (channel.hasPublish()) {
+            const operationId = channel.publish().json('operationId')
+            const generator = new TypeScriptGenerator({
+                modelType: 'interface',
+                constraints: {
+                    modelName: ({ modelName }) => {
+                        modelName = operationId
+                        return modelName
+                    }
+                }
+            })
+            channel.publish().messages().map(async message => {
+                const { _json: { payload } } = message
+                const models = await generator.generate({
+                    type: payload.type,
+                    additionalProperties: payload.additionalProperties,
+                    properties: payload.properties
+                })
+                // Todo: create files based on the models generated.
+            })
+        }
+    })
+}
+
+function mkDirByPathSync(targetDir: string){
+    const seperator = path.sep
+    const initDir = path.isAbsolute(targetDir) ? seperator : ''
+    const baseDir = '.'
+
+    targetDir.split(seperator).reduce((parentDir, childDir) => {
+        const currDir = path.resolve(baseDir, parentDir, childDir)
+        try {
+            fs.mkdirSync(currDir)
+        } catch (error) {
+            if(error.code === 'EEXIST'){
+                console.log(`Directory ${currDir} already exists!`)
+                return currDir
+            }
+            if (error.code === 'ENOENT') { 
+                throw new Error(`EACCES: permission denied, mkdir '${parentDir}'`);
+            }
+
+            const caughtErr = ['EACCES', 'EPERM', 'EISDIR'].indexOf(error.code) > -1;
+            if (!caughtErr || caughtErr && currDir === path.resolve(targetDir)) {
+                throw error
+            }
+        }
+        return currDir
+    }, initDir)
+}


### PR DESCRIPTION
Added support to create operations/types directory to categorize payloads, Added Modelina support to generate types based on message payloads

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->