### PR TITLE
fix: stop resolving config for ws server.

### DIFF
--- a/src/adapters/ws/server.ts
+++ b/src/adapters/ws/server.ts
@@ -5,7 +5,6 @@ import Adapter from '../../lib/adapter.js'
 import GleeConnection from '../../lib/connection.js'
 import GleeMessage from '../../lib/message.js'
 import GleeError from '../../errors/glee-error.js'
-import {WebsocketAdapterConfig} from '../../lib/index.js'
 
 type QueryData = {
   searchParams: URLSearchParams,

--- a/src/adapters/ws/server.ts
+++ b/src/adapters/ws/server.ts
@@ -107,8 +107,7 @@ class WebSocketsAdapter extends Adapter {
   }
 
   private async initializeConstants() {
-    const options: WebsocketAdapterConfig = await this.resolveProtocolConfig('ws')
-    const config = options?.server
+    const config = this.glee.options?.ws?.server
     const serverUrl = new URL(this.serverUrlExpanded)
     const wsHttpServer = config?.httpServer || http.createServer()
     const asyncapiServerPort = serverUrl.port || 80
@@ -116,7 +115,6 @@ class WebSocketsAdapter extends Adapter {
     const port = optionsPort || asyncapiServerPort
 
     return {
-      options,
       config,
       serverUrl,
       wsHttpServer,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
This is a quick fix for #436, where we are not resolving it and treating it as an object. 

Fixing this is tricky as any part of the config object could be a function or an object, so it is hard to figure out which object to resolve and which not to. Something to consider for https://github.com/asyncapi/glee/issues/392


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

Fixes #436 