### PR TITLE
fix: connection not initiated in MQTT due to broken firstConnect check

### DIFF
--- a/src/adapters/mqtt/index.ts
+++ b/src/adapters/mqtt/index.ts
@@ -52,14 +52,14 @@ class MqttAdapter extends Adapter {
     const X509SecurityReq = securityRequirements.find(
       (sec) => sec.type() === 'X509'
     )
-    
+
     return {
       userAndPasswordSecurityReq,
       X509SecurityReq
     }
 
   }
-  
+
   private async initializeClient(data: ClientData) {
 
     const {
@@ -171,7 +171,7 @@ class MqttAdapter extends Adapter {
         this.client.on('connect', connAckPacket => {
           const isSessionResume = connAckPacket.sessionPresent
 
-          if (!this.checkFirstConnect) {
+          if (!this.firstConnect) {
             this.firstConnect = true
             this.emit('connect', {
               name: this.name(),


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
- connection not initiated in MQTT due to broken firstConnect check
- lot's on info in the linked issue

**Related issue(s)**
- fixes #442 