### PR TITLE
feat: add AMQP 1.0 support and adapter for Glee

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10119,6 +10119,14 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
       "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
+    "rhea": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rhea/-/rhea-3.0.2.tgz",
+      "integrity": "sha512-0G1ZNM9yWin8VLvTxyISKH6KfR6gl1TW/1+5yMKPf2r1efhkzTLze09iFtT2vpDjuWIVtSmXz8r18lk/dO8qwQ==",
+      "requires": {
+        "debug": "^4.3.3"
+      }
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "path-to-regexp": "^6.2.0",
     "qs": "^6.11.0",
     "redis": "^4.0.2",
+    "rhea": "^3.0.2",
     "socket.io": "^4.1.2",
     "terminal-image": "^2.0.0",
     "typescript": "^4.5.4",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
- current decisions
    - use rabbitmq with amqp 1.0 plugin
         - https://www.rabbitmq.com/installing-plugins.html
         - https://www.rabbitmq.com/plugins.html
    - use rhea for amqp 1.0 support

**Related issue(s)**
- #258 