### PR TITLE
docs: add missing docs key to config file document

### DIFF
--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -18,10 +18,11 @@ This function must return an object with the following shape:
 export default async function () {
   return {
     glee: {},
+    docs: {},
+    cluster: {},
     kafka: {},
     websocket: {},
     mqtt: {},
-    cluster: {},
     http: {}
   }
 }


### PR DESCRIPTION
**Description**
The `docs` key is missing in one of the documentation paragraphs. I'm also taking the opportunity to group keys by "glee-related" stuff and protocols.

**Related issue(s)**
No issue