### PR TITLE
fix: removes Unused Imports Closes #527

### DIFF
--- a/test/lib/adapter.test.ts
+++ b/test/lib/adapter.test.ts
@@ -5,7 +5,6 @@ import GleeConnection from '../../src/lib/connection.js'
 import Glee from '../../src/lib/glee.js'
 import GleeMessage from '../../src/lib/message.js'
 import GleeAdapter from '../../src/lib/adapter.js'
-import { MiddlewareCallback } from '../../src/middlewares/index.d'
 import { jest } from '@jest/globals'
 
 const TEST_SERVER_NAME = 'test'


### PR DESCRIPTION
**Description**
PR aims to remove unused imports of import of 'MiddlewareCallback' from tests/lib/adapter.test.ts directory

**Related issue(s)**
Fixes #527 