### PR TITLE
fix: #461 Generating docs fails if project is a git repository

### DIFF
--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -12,7 +12,8 @@ export default async (spec, config, resDir) => {
     path.resolve(
       resDir ? resDir : './',
       configData?.folder ? configData.folder : 'docs'
-    )
+    ),
+    { forceWrite: true }
   )
   try {
     await generator.generateFromString(JSON.stringify(resolvedData))


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- This PR fixes #461
- Added `{ forceWrite: true }` in [https://github.com/freakfan15/glee/blob/461-generating-docs-fails-if-project-is-git-repo/src/lib/docs.ts](url) while creating the generator object.
- This will override the docs everytime, `npm run start` is run.
- Tested this by doing the same change in node modules of a new glee project and now it runs without any error every time.
<img width="1134" alt="image" src="https://github.com/asyncapi/glee/assets/54408801/60eb1297-a6c4-4b0c-b74e-861fbd869be9">

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->