### PR TITLE
fix: use channel.address instead of id

### DIFF
--- a/src/adapters/mqtt/index.ts
+++ b/src/adapters/mqtt/index.ts
@@ -110,7 +110,7 @@ class MqttAdapter extends Adapter {
     this.client.on('close', () => {
       this.emit('close', {
         connection: this.client,
-        channels: this.channelNames,
+        channels: this.channelAddresses,
       })
     })
 
@@ -140,7 +140,6 @@ class MqttAdapter extends Adapter {
   private subscribe(channels: string[]) {
     channels.forEach((channel) => {
       const binding = this.parsedAsyncAPI.channels().get(channel).bindings().get('mqtt')?.value()
-      console.log(binding)
       this.client.subscribe(channel, {
         qos: binding?.qos ? binding.qos : 0,
       }, (err, granted) => {
@@ -255,7 +254,6 @@ class MqttAdapter extends Adapter {
 
   _customAckHandler(channel, message, mqttPacket, done) {
     const msg = this._createMessage(mqttPacket as IPublishPacket)
-    console.log('Hello World')
 
     msg.on('processing:successful', () => done(MQTT_SUCCESS_REASON))
     msg.on('processing:failed', () => done(MQTT_UNSPECIFIED_ERROR_REASON))


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This small fix updates `channel.address()` instead of `channel.id()` in mqtt.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

Fixes #581 