### PR TITLE
fix: send messages to the address of the channel

### DIFF
--- a/src/adapters/mqtt/index.ts
+++ b/src/adapters/mqtt/index.ts
@@ -248,14 +248,11 @@ class MqttAdapter extends Adapter {
 
   _send(message: GleeMessage): Promise<void> {
     return new Promise((resolve, reject) => {
-      const binding = this.parsedAsyncAPI
-        .channels()
-        .get(message.channel)
-        .bindings()
-        .get('mqtt')
-        ?.value()
+      const channel = this.parsedAsyncAPI.channels().get(message.channel)
+      const address = channel.address()
+      const binding = channel.bindings().get('mqtt')?.value()
       this.client.publish(
-        message.channel,
+        address,
         message.payload,
         {
           qos: binding?.qos ? binding.qos : 2,

--- a/src/lib/functions.ts
+++ b/src/lib/functions.ts
@@ -152,7 +152,26 @@ export async function trigger({
         localServerProtocols.includes(serverProtocol) &&
         !isRemoteServer(parsedAsyncAPI, msg.server)
       const channelName = msg.channel || message.channel
-      const operations = parsedAsyncAPI.channels().get(channelName).operations().filterBySend()
+      const channel = parsedAsyncAPI.channels().get(channelName)
+
+      if (!channel) {
+        const warnMessage = `Failed to send: "${channelName}" channel not found. please make sure you have a channel named: "${channelName}" in your AsyncAPI file.`
+        logWarningMessage(warnMessage, {
+          highlightedWords: [channelName],
+        })
+        return
+      }
+
+      const operations = channel.operations().filterBySend()
+
+      if (operations.length === 0) {
+        const warnMessage = `Failed to send: No 'send' operation found for channel "${channelName}".`
+        logWarningMessage(warnMessage, {
+          highlightedWords: [channelName],
+        })
+        return
+      }
+
       operations.forEach(operation => {
         app.send(
           new GleeMessage({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "compilerOptions": {
+    "skipLibCheck": true,
     "outDir": "./dist",
     "allowJs": false,
     "target": "es6",
     "esModuleInterop": true,
     "moduleResolution": "nodenext",
-    "module": "es2020"
+    "module": "NodeNext"
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
**Description**

- fix the bug when Glee sends the message to the channel name instead of the channel address in MQTT.
- show a warning when the channel name is invalid when we send a message.
- show a warning when there is no send operation defined in the AsyncAPI file.

**Related issue(s)**
fixes #721