### PR TITLE
feat: run Glee in container, edit Glee local

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,4 +14,4 @@ indent_size = 2
 indent_style = tab
 
 [*.md]
-trim_trailing_whitespace = false
+trim_trailing_whitespace = false 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you have Docker installed, you can also create a container to run the develop
 ```bash
 docker compose up
 ```
-[Its usage is explained here](./docs/docker/usage.md)
+Its usage is explained [here](./docs/docker/usage.md)
 
 > For more information on how to install AsyncAPI CLI, you can review [CLI installation documentation](https://www.asyncapi.com/docs/tools/cli/installation)
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ asyncapi new glee
 
 After the installation is complete, follow the instructions to start the development server.
 
+If you have Docker installed, you can also create a container to run the development server by downloading the [docker-compose.yaml](https://example.com) file. Its usage is explained here [placeholder reference](https://example.com)
+
 > For more information on how to install AsyncAPI CLI, you can review [CLI installation documentation](https://www.asyncapi.com/docs/tools/cli/installation)
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ asyncapi new glee
 
 After the installation is complete, follow the instructions to start the development server.
 
-If you have Docker installed, you can also create a container to run the development server by downloading the [docker-compose.yaml](https://example.com) file. Its usage is explained here [placeholder reference](https://example.com)
+If you have Docker installed, you can also create a container to run the development server by downloading the [docker-compose.yaml](./docker-compose.yaml) file to the directory where you want to host your Glee project and run 
+```bash
+docker compose up
+```
+[Its usage is explained here](./docs/docker/usage.md)
 
 > For more information on how to install AsyncAPI CLI, you can review [CLI installation documentation](https://www.asyncapi.com/docs/tools/cli/installation)
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,24 +5,21 @@ services:
   glee:
     build:
       context: .
-      # do we need to switch to USER root?
       dockerfile_inline: |
         FROM asyncapi/cli
         USER root
-        RUN apk add --no-cache --virtual .gyp python3 make g++ && \
-            rm -rf /var/lib/apt/lists/* && \
-            asyncapi new glee && \
-            cd project && \
+        RUN asyncapi new glee --name=tutorial --template tutorial && \
+            cd tutorial && \
             npm install
         ENTRYPOINT 
     volumes:
-      - ${PWD}:/app/project 
+      - ${PWD}:/app/tutorial 
     networks:
       - default
     user: root # can we stick to default user and have glee file/folders editable by local user?
     entrypoint: []
-    working_dir: /app/project
-    command: npm run dev
+    working_dir: /app/tutorial
+    command: sleep infinity
    
 networks:
   default: {}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,27 @@
+# draft, work on permissions for glee files/folders
+version: '3'
+
+services:
+  glee:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM asyncapi/cli
+        USER root
+        RUN apk add --no-cache --virtual .gyp python3 make g++ && \
+            rm -rf /var/lib/apt/lists/* && \
+            asyncapi new glee && \
+            cd project && \
+            npm install
+        ENTRYPOINT 
+    volumes:
+      - ${PWD}:/app/project 
+    networks:
+      - default
+    user: root
+    entrypoint: []
+    working_dir: /app/project
+    command: npm run dev
+   
+networks:
+  default: {}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
   glee:
     build:
       context: .
+      # do we need to switch to USER root?
       dockerfile_inline: |
         FROM asyncapi/cli
         USER root
@@ -18,7 +19,7 @@ services:
       - ${PWD}:/app/project 
     networks:
       - default
-    user: root
+    user: root # can we stick to default user and have glee file/folders editable by local user?
     entrypoint: []
     working_dir: /app/project
     command: npm run dev

--- a/docs/docker/usage.md
+++ b/docs/docker/usage.md
@@ -1,4 +1,5 @@
 Tentative usage. still buggy
+Validate in Linux (raspberry), windows and ask some-one to validate in macOS
 
 
 # developing the functionality
@@ -17,8 +18,9 @@ Tentative usage. still buggy
 - run docker command to open a container command prompt: docker exec -it name-of-container sh 
 ### at container command prompt
 - create glee project e.g. asyncapi new glee --name=tutorial --template tutorial
-- follow instructions to install and launch glee
-- change permission on Glee files so they can be edited in local file system with command chown.....
+- follow instructions to install glee (npm install)
+- change permission on glee files so they can be edited in local file system with command chown.....
+- follow instructions to launch glee (npm run dev)
 - monitor glee log
 - terminate glee server with ctrl-c
 ### in local workstation

--- a/docs/docker/usage.md
+++ b/docs/docker/usage.md
@@ -1,0 +1,1 @@
+How to use the docker-compose file to launch Glee

--- a/docs/docker/usage.md
+++ b/docs/docker/usage.md
@@ -1,1 +1,18 @@
-How to use the docker-compose file to launch Glee
+# Issues in developing the functionality
+## Concept
+- Build image on base async/cli dressed up with python and .gyp
+- Spawn glee project
+- Install the project
+- File the image
+- Run container from this image where glee project is bound to local file system and run Glee
+
+## Issues
+- When you delete glee project in local file, this is somehow remembered. Glee project does not come back at next "docker compose up"
+- When you locally change a file in glee project, server is not aware. You can "kick the server"e.g. with local chown but that is strange workaround
+
+
+## Way forward
+- improve my understanding of docker (but both two issues relate to how binding works. And that is very tricky stuff with big risk to go into platform dependent approaches)
+- explore devcontainer
+
+Devcontainer (github codespaces; codesandbox) looks quite interesting. But be careful. The solution only has to be "more simple" than maintaining a proper local development environment. 

--- a/docs/docker/usage.md
+++ b/docs/docker/usage.md
@@ -3,26 +3,26 @@ Tentative usage. still buggy
 
 # developing the functionality
 ## Concept
+- Run container forever (sleep infinity) for asyncapi/cli image
+- Open command prompt in container
 - Spawn glee project
-- Install the project
-- File the image
-- Run container from this image where glee project is bound to local file system 
-- Make container persitent with sleep command
-- Open command-prompt in container for Glee commands (npm run dev, ctrl-c) and monitoring glee log
-- open editor in local file system to edit the glee project
+- Glee files are now visible in local filesystem for editing
 
 ## Usage
 ### prepare your project
 - install docker on your workstation (see docker website)
-- create a local folder to host your Glee project
+- create a local folder to host your Glee projects
 - download docker-compose.yaml into this folder
-- run the docker compose up command. This brings up a container with Glee
+- run the docker compose up command. This brings up a container with asyncapi/cli
 - run docker command to open a container command prompt: docker exec -it name-of-container sh 
 ### at container command prompt
-- launch glee server with npm: npm run dev
-- terminate glee with ctrl-C
+- create glee project e.g. asyncapi new glee --name=tutorial --template tutorial
+- follow instructions to install and launch glee
+- change permission on Glee files so they can be edited in local file system with command chown.....
 - monitor glee log
+- terminate glee server with ctrl-c
 ### in local workstation
+- navigate to glee project (one directory down from docker-compose file)
 - edit asyncapi.yaml to bind Glee server to your broker of preference (server: host, protocol).
 On file of change Glee notices and rebuilds/relaunches the server
 - edit a function in function folder to define new behavior
@@ -30,6 +30,7 @@ On file of change Glee notices and rebuilds/relaunches the server
 - refer to Glee tutorial for help with Glee itself (https://www.asyncapi.com/docs/tools/glee, https://www.asyncapi.com/docs/tutorials/generate-code)
 
 ## Pitfalls
+- websocket port at glee server: xxxxxxxx
 - you may want to reset your Glee contents. Do not remove the local folder (this gives weird Docker issues). Recommended approach: 
     - open a container command prompt
     - go one directory up (cd ..)

--- a/docs/docker/usage.md
+++ b/docs/docker/usage.md
@@ -1,18 +1,38 @@
-# Issues in developing the functionality
+Tentative usage. still buggy
+
+
+# developing the functionality
 ## Concept
-- Build image on base async/cli dressed up with python and .gyp
 - Spawn glee project
 - Install the project
 - File the image
-- Run container from this image where glee project is bound to local file system and run Glee
+- Run container from this image where glee project is bound to local file system 
+- Make container persitent with sleep command
+- Open command-prompt in container for Glee commands (npm run dev, ctrl-c) and monitoring glee log
+- open editor in local file system to edit the glee project
 
-## Issues
-- When you delete glee project in local file, this is somehow remembered. Glee project does not come back at next "docker compose up"
-- When you locally change a file in glee project, server is not aware. You can "kick the server"e.g. with local chown but that is strange workaround
+## Usage
+### prepare your project
+- install docker on your workstation (see docker website)
+- create a local folder to host your Glee project
+- download docker-compose.yaml into this folder
+- run the docker compose up command. This brings up a container with Glee
+- run docker command to open a container command prompt: docker exec -it name-of-container sh 
+### at container command prompt
+- launch glee server with npm: npm run dev
+- terminate glee with ctrl-C
+- monitor glee log
+### in local workstation
+- edit asyncapi.yaml to bind Glee server to your broker of preference (server: host, protocol).
+On file of change Glee notices and rebuilds/relaunches the server
+- edit a function in function folder to define new behavior
+- add operations to asyncapi.yaml
+- refer to Glee tutorial for help with Glee itself (https://www.asyncapi.com/docs/tools/glee, https://www.asyncapi.com/docs/tutorials/generate-code)
 
+## Pitfalls
+- you may want to reset your Glee contents. Do not remove the local folder (this gives weird Docker issues). Recommended approach: 
+    - open a container command prompt
+    - go one directory up (cd ..)
+    - force-write new glee project e.g. asyncapi new glee --name=tutorial --template tutorial --force-write
+    - Follow instructions to start Glee
 
-## Way forward
-- improve my understanding of docker (but both two issues relate to how binding works. And that is very tricky stuff with big risk to go into platform dependent approaches)
-- explore devcontainer
-
-Devcontainer (github codespaces; codesandbox) looks quite interesting. But be careful. The solution only has to be "more simple" than maintaining a proper local development environment. 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
Setting/maintaining a fully functional node environment on local machine can be overwhelming and hard to debug. A container is much easier to deploy/manage

*How will this change help?*
The prerequisite effort to install Docker or equivalent is shared over many projects.
On download of the compose.yaml a simple "docker compose up" launches the Glee server with default settings. From there you can modify the Glee files and stop/restart the Glee server to explore all features of Glee

No need to worry about install of node, .gyp, python etc

**Related issue(s)**
Resolves #735 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->