### PR TITLE
chore: install changelog with pnpm instead

### DIFF
--- a/.github/workflows/release-with-changesets.yml
+++ b/.github/workflows/release-with-changesets.yml
@@ -95,7 +95,7 @@ jobs:
       - if: steps.packagejson.outputs.exists == 'true'
         name: Install changelog
         shell: bash
-        run: npm install @changesets/changelog-git@0.2.0
+        run: pnpm install @changesets/changelog-git@0.2.0
       - if: steps.packagejson.outputs.exists == 'true'
         name: Publish to any of NPM, Github, and Docker Hub
         uses: changesets/action@v1


### PR DESCRIPTION
Installing the changelog package with pnpm instead of npm. I tried the rest of the steps locally and they work. Is this the last try? 😅 