### PR TITLE
chore: publish as public packages

### DIFF
--- a/.changeset/tame-clouds-turn.md
+++ b/.changeset/tame-clouds-turn.md
@@ -1,0 +1,11 @@
+---
+"@asyncapi/glee-redis-cluster-adapter": minor
+"@asyncapi/glee-web-server-adapter": minor
+"@asyncapi/glee-socketio-adapter": minor
+"@asyncapi/glee-kafka-adapter": minor
+"@asyncapi/glee-mqtt-adapter": minor
+"@asyncapi/glee-shared-utils": minor
+"@asyncapi/glee-web-adapter": minor
+---
+
+Publish packages to npm as public

--- a/packages/kafka-adapter/package.json
+++ b/packages/kafka-adapter/package.json
@@ -37,5 +37,8 @@
     "typedoc-plugin-markdown": "^4.2.9",
     "typescript": "^4.5.4"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/mqtt-adapter/package.json
+++ b/packages/mqtt-adapter/package.json
@@ -37,5 +37,8 @@
     "typedoc-plugin-markdown": "^4.2.9",
     "typescript": "^4.5.4"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/redis-cluster-adapter/package.json
+++ b/packages/redis-cluster-adapter/package.json
@@ -37,5 +37,8 @@
     "typedoc-plugin-markdown": "^4.2.9",
     "typescript": "^4.5.4"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -32,5 +32,8 @@
     "eslint-plugin-security": "^1.4.0",
     "eslint-plugin-sonarjs": "^0.19.0",
     "typescript": "^4.5.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/socket.io-adapter/package.json
+++ b/packages/socket.io-adapter/package.json
@@ -37,5 +37,8 @@
     "typedoc-plugin-markdown": "^4.2.9",
     "typescript": "^4.5.4"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/web-adapter/package.json
+++ b/packages/web-adapter/package.json
@@ -42,5 +42,8 @@
     "typedoc-plugin-markdown": "^4.2.9",
     "typescript": "^4.5.4"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/web-server-adapter/package.json
+++ b/packages/web-server-adapter/package.json
@@ -41,5 +41,8 @@
     "typedoc-plugin-markdown": "^4.2.9",
     "typescript": "^4.5.4"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
Yay! The release worked. However, some packages are not marked as public and therefore couldn't be published to npm. Fixing it here.